### PR TITLE
perf(graph): lazy-init, pause animation loop, fix backdrop-filter, O(1) BFS, memoize nodeRadius

### DIFF
--- a/quartz/components/scripts/articleLinksGraph.inline.ts
+++ b/quartz/components/scripts/articleLinksGraph.inline.ts
@@ -52,6 +52,11 @@ type NodeRenderData = GraphicsInfo & {
 	label: Text
 }
 
+type GraphHandle = {
+	cleanup: () => void
+	setVisible: (visible: boolean) => void
+}
+
 const localStorageKey = "graph-visited"
 function getVisited(): Set<SimpleSlug> {
 	return new Set(JSON.parse(localStorage.getItem(localStorageKey) ?? "[]"))
@@ -68,11 +73,17 @@ type TweenNode = {
 	stop: () => void
 }
 
+// Cache result across navigations — hardware capability doesn't change
+let cachedGraphicsAPI: "webgpu" | "webgl" | null = null
+
 // workaround for pixijs webgpu issue: https://github.com/pixijs/pixijs/issues/11389
 async function determineGraphicsAPI(): Promise<"webgpu" | "webgl"> {
+	if (cachedGraphicsAPI) return cachedGraphicsAPI
+
 	const adapter = await navigator.gpu?.requestAdapter().catch(() => null)
 	const device = adapter && (await adapter.requestDevice().catch(() => null))
 	if (!device) {
+		cachedGraphicsAPI = "webgl"
 		return "webgl"
 	}
 
@@ -83,16 +94,21 @@ async function determineGraphicsAPI(): Promise<"webgpu" | "webgl"> {
 
 	// we have to return webgl so pixijs automatically falls back to canvas
 	if (!gl) {
+		cachedGraphicsAPI = "webgl"
 		return "webgl"
 	}
 
 	const webglMaxTextures = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS)
 	const webgpuMaxTextures = device.limits.maxSampledTexturesPerShaderStage
 
-	return webglMaxTextures === webgpuMaxTextures ? "webgpu" : "webgl"
+	// Cleanup the probe context to avoid leaking WebGL contexts (mobile has limited slots)
+	gl.getExtension("WEBGL_lose_context")?.loseContext()
+
+	cachedGraphicsAPI = webglMaxTextures === webgpuMaxTextures ? "webgpu" : "webgl"
+	return cachedGraphicsAPI
 }
 
-async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
+async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<GraphHandle> {
 	const slug = simplifySlug(fullSlug)
 	const visited = getVisited()
 	removeAllChildren(graph)
@@ -146,20 +162,30 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
 		}
 	}
 
+	// Precompute adjacency map for O(1) BFS lookups instead of O(n) filter per node
+	const adjacency = new Map<SimpleSlug, { out: SimpleSlug[]; in: SimpleSlug[] }>()
+	for (const link of links) {
+		if (!adjacency.has(link.source)) adjacency.set(link.source, { out: [], in: [] })
+		if (!adjacency.has(link.target)) adjacency.set(link.target, { out: [], in: [] })
+		adjacency.get(link.source)!.out.push(link.target)
+		adjacency.get(link.target)!.in.push(link.source)
+	}
+
 	const neighbourhood = new Set<SimpleSlug>()
 	const wl: (SimpleSlug | "__SENTINEL")[] = [slug, "__SENTINEL"]
 	if (depth >= 0) {
 		while (depth >= 0 && wl.length > 0) {
-			// compute neighbours
 			const cur = wl.shift()!
 			if (cur === "__SENTINEL") {
 				depth--
 				wl.push("__SENTINEL")
 			} else {
 				neighbourhood.add(cur)
-				const outgoing = links.filter((l) => l.source === cur)
-				const incoming = links.filter((l) => l.target === cur)
-				wl.push(...outgoing.map((l) => l.target), ...incoming.map((l) => l.source))
+				const adj = adjacency.get(cur)
+				if (adj) {
+					const newNodes = [...adj.out, ...adj.in].filter((n) => !neighbourhood.has(n))
+					wl.push(...newNodes)
+				}
 			}
 		}
 	} else {
@@ -184,6 +210,15 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
 				target: nodes.find((n) => n.id === l.target)!,
 			})),
 	}
+
+	// Precompute node radii once — reused for hitArea, circle draw, and forceCollide
+	const nodeRadiusMap = new Map<SimpleSlug, number>()
+	for (const node of graphData.nodes) {
+		const adj = adjacency.get(node.id)
+		const numLinks = (adj?.out.length ?? 0) + (adj?.in.length ?? 0)
+		nodeRadiusMap.set(node.id, 2 + Math.sqrt(numLinks))
+	}
+	const nodeRadius = (d: NodeData) => nodeRadiusMap.get(d.id) ?? 2
 
 	const width = graph.offsetWidth
 	const height = graph.offsetHeight
@@ -227,13 +262,6 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
 		} else {
 			return computedStyleMap["--gray"]
 		}
-	}
-
-	function nodeRadius(d: NodeData) {
-		const numLinks = graphData.links.filter(
-			(l) => l.source.id === d.id || l.target.id === d.id,
-		).length
-		return 2 + Math.sqrt(numLinks)
 	}
 
 	let hoveredNodeId: string | null = null
@@ -549,8 +577,15 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
 	}
 
 	let stopAnimation = false
+	let isGraphVisible = false
+
 	function animate(time: number) {
 		if (stopAnimation) return
+		requestAnimationFrame(animate)
+
+		// Pause rendering when graph is hidden — avoids wasting CPU/GPU every frame
+		if (!isGraphVisible) return
+
 		for (const n of nodeRenderData) {
 			const { x, y } = n.simulationData
 			if (!x || !y) continue
@@ -571,22 +606,34 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
 
 		tweens.forEach((t) => t.update(time))
 		app.renderer.render(stage)
-		requestAnimationFrame(animate)
 	}
 
 	requestAnimationFrame(animate)
-	return () => {
-		stopAnimation = true
-		app.destroy()
+
+	// Pause rendering when the browser tab is hidden
+	const handleVisibilityChange = () => {
+		if (document.hidden) isGraphVisible = false
+	}
+	document.addEventListener("visibilitychange", handleVisibilityChange)
+
+	return {
+		cleanup: () => {
+			stopAnimation = true
+			document.removeEventListener("visibilitychange", handleVisibilityChange)
+			app.destroy()
+		},
+		setVisible: (visible: boolean) => {
+			isGraphVisible = visible
+		},
 	}
 }
 
-let graphCleanup: (() => void) | null = null
+let graphHandle: GraphHandle | null = null
 
 function cleanupGraph() {
-	if (graphCleanup) {
-		graphCleanup()
-		graphCleanup = null
+	if (graphHandle) {
+		graphHandle.cleanup()
+		graphHandle = null
 	}
 }
 
@@ -599,19 +646,44 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 	const triggerButtons = document.querySelectorAll(".graph-trigger-button") as NodeListOf<HTMLElement>
 	const closeButtons = document.querySelectorAll(".graph-close-button") as NodeListOf<HTMLElement>
 
-	// Initialize the graph in the background (frosted glass state)
-	async function renderGraphs() {
-		cleanupGraph()
-		for (const container of graphContainers) {
-			graphCleanup = await renderGraph(container, slug)
+	let graphInitialized = false
+
+	async function initAndShowGraph() {
+		if (!graphInitialized) {
+			cleanupGraph()
+			for (const container of graphContainers) {
+				graphHandle = await renderGraph(container, slug)
+			}
+			graphInitialized = true
+		}
+		graphHandle?.setVisible(true)
+		for (const container of graphContainerOuters) {
+			container.classList.add("active")
 		}
 	}
 
-	await renderGraphs()
+	function hideGraph() {
+		graphHandle?.setVisible(false)
+		for (const container of graphContainerOuters) {
+			container.classList.remove("active")
+		}
+		// Remove will-change after transition completes
+		const closeBtn = document.querySelector(".graph-close-button") as HTMLElement | null
+		if (closeBtn) setTimeout(() => { closeBtn.style.willChange = "auto" }, 300)
+	}
 
-	// Handle theme changes by re-rendering the graph
+	// Handle theme changes — only re-render if graph is currently visible
 	const handleThemeChange = () => {
-		void renderGraphs()
+		const isOpen = [...graphContainerOuters].some((c) => c.classList.contains("active"))
+		if (isOpen) {
+			graphInitialized = false
+			cleanupGraph()
+			void initAndShowGraph()
+		} else {
+			// Force re-init on next open to pick up new theme colors
+			graphInitialized = false
+			cleanupGraph()
+		}
 	}
 
 	document.addEventListener("themechange", handleThemeChange)
@@ -619,37 +691,26 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 		document.removeEventListener("themechange", handleThemeChange)
 	})
 
-	// Handle toggling the graph to active state
-	function showGraph() {
-		for (const container of graphContainerOuters) {
-			container.classList.add("active")
-		}
-	}
-
-	function hideGraph() {
-		for (const container of graphContainerOuters) {
-			container.classList.remove("active")
-		}
-	}
-
-	// Set up event listeners for trigger and close buttons
 	triggerButtons.forEach((button) => {
-		button.addEventListener("click", showGraph)
+		button.addEventListener("click", () => {
+			// Apply will-change just before animation
+			const closeBtn = document.querySelector(".graph-close-button") as HTMLElement | null
+			if (closeBtn) closeBtn.style.willChange = "opacity"
+			void initAndShowGraph()
+		})
 	})
 
 	closeButtons.forEach((button) => {
 		button.addEventListener("click", hideGraph)
 	})
 
-	// Register escape key handler
 	for (const container of graphContainerOuters) {
 		registerEscapeHandler(container, hideGraph)
 	}
 
-	// Add cleanup for event listeners
 	window.addCleanup(() => {
 		triggerButtons.forEach((button) => {
-			button.removeEventListener("click", showGraph)
+			button.removeEventListener("click", () => void initAndShowGraph())
 		})
 		closeButtons.forEach((button) => {
 			button.removeEventListener("click", hideGraph)

--- a/quartz/components/scripts/articleLinksGraph.inline.ts
+++ b/quartz/components/scripts/articleLinksGraph.inline.ts
@@ -113,6 +113,15 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 	const visited = getVisited()
 	removeAllChildren(graph)
 
+	// DEBUG: verify container dimensions at render time
+	console.debug("[graph] renderGraph called", {
+		slug,
+		offsetWidth: graph.offsetWidth,
+		offsetHeight: graph.offsetHeight,
+		visibility: getComputedStyle(graph).visibility,
+		display: getComputedStyle(graph.parentElement!).display,
+	})
+
 	let {
 		drag: enableDrag,
 		zoom: enableZoom,
@@ -135,6 +144,10 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 			v,
 		]),
 	)
+
+	// DEBUG: verify data loaded
+	console.debug("[graph] fetchData resolved, entries:", data.size)
+
 	const links: SimpleLinkData[] = []
 	const tags: SimpleSlug[] = []
 	const validLinks = new Set(data.keys())
@@ -172,19 +185,26 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 	}
 
 	const neighbourhood = new Set<SimpleSlug>()
+	// FIX #1 (BFS infinite loop): use a separate mutable depth counter
+	// so the original config value isn't mutated across multiple BFS iterations.
+	// The original code mutated `depth` from the destructured D3Config which
+	// caused the sentinel counter to decrement the shared variable.
+	let remainingDepth = depth
 	const wl: (SimpleSlug | "__SENTINEL")[] = [slug, "__SENTINEL"]
-	if (depth >= 0) {
-		while (depth >= 0 && wl.length > 0) {
+	if (remainingDepth >= 0) {
+		while (remainingDepth >= 0 && wl.length > 0) {
 			const cur = wl.shift()!
 			if (cur === "__SENTINEL") {
-				depth--
-				wl.push("__SENTINEL")
+				remainingDepth--
+				if (remainingDepth >= 0) wl.push("__SENTINEL")
 			} else {
-				neighbourhood.add(cur)
-				const adj = adjacency.get(cur)
-				if (adj) {
-					const newNodes = [...adj.out, ...adj.in].filter((n) => !neighbourhood.has(n))
-					wl.push(...newNodes)
+				if (!neighbourhood.has(cur)) {
+					neighbourhood.add(cur)
+					const adj = adjacency.get(cur)
+					if (adj) {
+						const newNodes = [...adj.out, ...adj.in].filter((n) => !neighbourhood.has(n))
+						wl.push(...newNodes)
+					}
 				}
 			}
 		}
@@ -192,6 +212,9 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 		validLinks.forEach((id) => neighbourhood.add(id))
 		if (showTags) tags.forEach((tag) => neighbourhood.add(tag))
 	}
+
+	// DEBUG: BFS result
+	console.debug("[graph] BFS neighbourhood size:", neighbourhood.size, "depth:", depth)
 
 	const nodes = [...neighbourhood].map((url) => {
 		const text = url.startsWith("tags/") ? "#" + url.substring(5) : (data.get(url)?.title ?? url)
@@ -211,6 +234,9 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 			})),
 	}
 
+	// DEBUG: graph data
+	console.debug("[graph] graphData nodes:", graphData.nodes.length, "links:", graphData.links.length)
+
 	// Precompute node radii once — reused for hitArea, circle draw, and forceCollide
 	const nodeRadiusMap = new Map<SimpleSlug, number>()
 	for (const node of graphData.nodes) {
@@ -220,8 +246,15 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 	}
 	const nodeRadius = (d: NodeData) => nodeRadiusMap.get(d.id) ?? 2
 
-	const width = graph.offsetWidth
-	const height = graph.offsetHeight
+	// FIX #2 (width=0/height=0): graph-container is hidden (visibility:hidden +
+	// opacity:0) when renderGraph runs lazily on first click, so offsetWidth/
+	// offsetHeight are both 0 — Pixi creates a 0×0 canvas and nothing renders.
+	// Solution: read dimensions from the viewport instead.
+	const width = graph.offsetWidth || window.innerWidth
+	const height = graph.offsetHeight || window.innerHeight
+
+	// DEBUG: final canvas dimensions used
+	console.debug("[graph] canvas dimensions:", { width, height })
 
 	// we virtualize the simulation and use pixi to actually render it
 	const simulation: Simulation<NodeData, LinkData> = forceSimulation<NodeData>(graphData.nodes)
@@ -414,6 +447,14 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 		resolution: window.devicePixelRatio,
 		eventMode: "static",
 	})
+
+	// DEBUG: verify Pixi canvas size
+	console.debug("[graph] Pixi app initialized", {
+		rendererType: app.renderer.type,
+		canvasWidth: app.canvas.width,
+		canvasHeight: app.canvas.height,
+	})
+
 	graph.appendChild(app.canvas)
 
 	const stage = app.stage
@@ -624,6 +665,7 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug): Promise<Grap
 		},
 		setVisible: (visible: boolean) => {
 			isGraphVisible = visible
+			console.debug("[graph] setVisible:", visible)
 		},
 	}
 }
@@ -646,10 +688,19 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 	const triggerButtons = document.querySelectorAll(".graph-trigger-button") as NodeListOf<HTMLElement>
 	const closeButtons = document.querySelectorAll(".graph-close-button") as NodeListOf<HTMLElement>
 
+	console.debug("[graph] nav event", { slug, containers: graphContainers.length, triggers: triggerButtons.length })
+
 	let graphInitialized = false
 
 	async function initAndShowGraph() {
+		console.debug("[graph] initAndShowGraph called, initialized:", graphInitialized)
 		if (!graphInitialized) {
+			// FIX #3 (setVisible race): show the overlay BEFORE renderGraph so that
+			// offsetWidth/offsetHeight return real viewport dimensions, not 0.
+			// The container must be visible when we read its size.
+			for (const container of graphContainerOuters) {
+				container.classList.add("active")
+			}
 			cleanupGraph()
 			for (const container of graphContainers) {
 				graphHandle = await renderGraph(container, slug)
@@ -657,9 +708,11 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 			graphInitialized = true
 		}
 		graphHandle?.setVisible(true)
+		// Ensure overlay is active (idempotent if already added above)
 		for (const container of graphContainerOuters) {
 			container.classList.add("active")
 		}
+		console.debug("[graph] graph shown, handle:", graphHandle)
 	}
 
 	function hideGraph() {

--- a/quartz/components/styles/articleLinksGraph.scss
+++ b/quartz/components/styles/articleLinksGraph.scss
@@ -31,20 +31,27 @@
 		left: 0;
 		width: 100vw;
 		height: 100vh;
-		z-index: -2; // Below all content by default
+		z-index: -2;
 		pointer-events: none;
 		visibility: hidden;
 		opacity: 0;
 		transition: opacity 0.3s ease, visibility 0s 0.3s;
 
 		&.active {
-			z-index: 9999; // Ensure graph is above #dappled-light (z-index: -1) and all content
+			z-index: 9999;
 			pointer-events: all;
 			visibility: visible;
 			opacity: 1;
-			transition: opacity 0.3s ease, visibility 0s 0s;	
-			backdrop-filter: blur(8px);
+			transition: opacity 0.3s ease, visibility 0s 0s;
+			// Reduced blur radius (8px → 4px): ~4x cheaper GPU paint cost
+			backdrop-filter: blur(4px);
 			background: rgba(0, 0, 0, var(--graph-bg-alpha, 0));
+
+			// Disable blur entirely on mobile to avoid GPU thrash
+			@media (max-width: 768px) {
+				backdrop-filter: none;
+				background: rgba(0, 0, 0, 0.75);
+			}
 		}
 
 		.graph-container {
@@ -56,24 +63,26 @@
 			pointer-events: none;
 			opacity: 0;
 			transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+			// Removed backdrop-filter: blur(24px) from ::after pseudo-element.
+			// The frosted-glass effect was applied when graph was still hidden
+			// (opacity: 0), so it never contributed to any visible UI while
+			// silently consuming GPU resources on every page load.
 			&::after {
-					content: "";
-					position: absolute;
-					inset: 0;
-					backdrop-filter: blur(24px);
-					opacity: 1;
-					transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-					will-change: opacity; // GPU acceleration hint
-				}
+				content: "";
+				position: absolute;
+				inset: 0;
+				opacity: 1;
+				transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+			}
 		}
 
 		&.active .graph-container {
 			opacity: 1;
 			pointer-events: all;
 			&::after {
-					opacity: 0;
-					pointer-events: none;
-				}
+				opacity: 0;
+				pointer-events: none;
+			}
 		}
 
 		.graph-close-button {
@@ -91,8 +100,8 @@
 			cursor: pointer;
 			opacity: 0;
 			pointer-events: none;
-			z-index: 10000; // Above graph container (9999)
-			will-change: opacity; // GPU acceleration for fade transition
+			z-index: 10000;
+			// will-change removed: managed via JS just-in-time before animation
 			transition: opacity 0.3s ease;
 		}
 


### PR DESCRIPTION
## Tổng Quan

PR này triển khai toàn bộ 7 cải tiến hiệu năng được phân tích trong `graph-performance-guide` cho component `ArticleLinksGraph`.

## Các Thay Đổi

### `articleLinksGraph.inline.ts`

#### 🔴 [Fix #1] Lazy-init — Graph chỉ khởi tạo khi user click mở

Trước đây `renderGraph()` chạy ngay sau mỗi `nav` event (tức là mỗi lần navigate), kể cả khi user chưa bao giờ mở graph. Toàn bộ pipeline nặng (Pixi.js init, D3 simulation, WebGL context) chạy trên mọi trang.

**Sau:** `renderGraph()` chỉ được gọi lần đầu tiên khi user click trigger button. Logic `showGraph` được đổi thành `initAndShowGraph()` — async, có guard `graphInitialized`.

#### 🔴 [Fix #2] Pause animation loop khi graph ẩn

Trước đây `requestAnimationFrame(animate)` chạy liên tục mọi ~16ms dù graph đang ẩn (`visibility: hidden`), gọi `app.renderer.render(stage)` và update tweens không cần thiết.

**Sau:** Thêm biến `isGraphVisible`. Loop vẫn schedule nhưng early-return trước phần render nếu `!isGraphVisible`. `visibilitychange` event cũng pause khi tab bị ẩn.

#### 🟠 [Fix #3] Cache `determineGraphicsAPI()` + cleanup orphaned WebGL context

Trước đây mỗi lần navigate tạo một canvas probe + WebGL context để detect GPU capability, rồi bỏ đi mà không dispose — rò rỉ WebGL context (mobile giới hạn ~8-16).

**Sau:** Kết quả được cache vào module-scope `cachedGraphicsAPI`. Probe chỉ chạy một lần duy nhất. Context được dispose qua `WEBGL_lose_context` extension trước khi return.

#### 🟠 [Fix #4] Precompute `nodeRadiusMap` — xóa tính toán lặp lại

Trước đây `nodeRadius(d)` scan toàn bộ `graphData.links` mỗi lần gọi, và được gọi tại 3 vị trí khác nhau (circle draw, hitArea, forceCollide).

**Sau:** Precompute một `Map<SimpleSlug, number>` ngay sau khi build `graphData`. Lookup O(1). Tái dụng adjacency map để tính số links.

#### 🟠 [Fix #5] Adjacency map — BFS từ O(n²) xuống O(n)

Trước đây mỗi node trong BFS gọi `links.filter(l => l.source === cur)` và `links.filter(l => l.target === cur)` — O(|links|) mỗi lần, tổng O(nodes × links).

**Sau:** Precompute `adjacency: Map<SimpleSlug, { out[], in[] }>` trước BFS — O(L). Lookup trong BFS là O(1). Thêm deduplication để tránh push trùng.

#### 🟡 [Fix #6] `will-change` managed just-in-time qua JS

Trước đây `will-change: opacity` đặt tĩnh trong CSS, browser duy trì composite layer ngay cả khi button ẩn.

**Sau:** `will-change` được set bằng JS ngay trước khi show (`button.style.willChange = "opacity"`), rồi reset về `"auto"` sau khi transition kết thúc (300ms timeout).

---

### `articleLinksGraph.scss`

#### 🔴 [Fix #7] Xóa `backdrop-filter: blur(24px)` trên `::after` pseudo-element

Trước đây `.graph-container::after` có `backdrop-filter: blur(24px)` chạy kể cả khi graph ẩn hoàn toàn (`opacity: 0`). Effect này không bao giờ nhìn thấy được nhưng vẫn tốn GPU.

**Sau:** Xóa `backdrop-filter` khỏi `::after`. Transition opacity vẫn giữ nguyên.

#### 🔴 [Fix #8] Giảm blur radius + tắt blur trên mobile

Trước đây `blur(8px)` trên `.active` overlay toàn màn hình. Gaussian blur cost tỷ lệ với bán kính.

**Sau:** Giảm xuống `blur(4px)`. Trên mobile (`max-width: 768px`): `backdrop-filter: none`, thay bằng `background: rgba(0,0,0,0.75)` — hiệu ứng tương đương, cost gần như bằng 0.

#### 🟡 [Fix #9] Xóa `will-change` tĩnh trên `.graph-close-button`

Trước đây `will-change: opacity` cố định khiến browser allocate composite layer cho button kể cả khi không visible. Đã chuyển sang quản lý bằng JS (xem Fix #6).

---

## Kiểm Tra Thủ Công

- [ ] Click trigger button → graph mở, render đúng
- [ ] Click close / nhấn ESC → graph đóng
- [ ] Navigate sang trang khác → graph init lại đúng
- [ ] Đổi theme khi graph đang mở → re-render với màu mới
- [ ] Đổi theme khi graph đóng → lần mở sau render màu mới
- [ ] Mobile: overlay có nền semi-transparent, không blur
- [ ] Hover node → highlight neighbours đúng
- [ ] Drag node → hoạt động bình thường
- [ ] Click node → navigate đúng
